### PR TITLE
Add support to detect Joomla 3.8+.

### DIFF
--- a/jamss.php
+++ b/jamss.php
@@ -445,12 +445,15 @@ function whichJoomla() {
     $f1 = "./includes/version.php";
     $f2 = "./libraries/joomla/version.php";
     $f3 = "./libraries/cms/version/version.php";
+    $f38 = "./libraries/src/Version.php";
     if (file_exists($f1)) { // Joomla 1.0 & 1.7
         $vFile = file_get_contents($f1);
     } elseif (file_exists($f2)) { // Joomla 1.5 & 1.6
         $vFile = file_get_contents($f2);
     } elseif (file_exists($f3)) { // Joomla 2.5 & 3.x
         $vFile = file_get_contents($f3);
+    } elseif (file_exists($f38)) { // Joomla 3.8+ Added by @chris001 EspaceNetworks.com
+        $vFile = file_get_contents($f38);
     } else { // no Joomla found
         return NULL;
     }


### PR DESCRIPTION
Add support to detect Joomla 3.8+, the file `Version.php` is in a new location.